### PR TITLE
Evaluar e imprimir

### DIFF
--- a/godot/addons/refactorings/refactor_tooltip.gd
+++ b/godot/addons/refactorings/refactor_tooltip.gd
@@ -31,7 +31,14 @@ func _ready():
 		queue_free()
 		refactorings.inline_variable()
 	)
-
+	%Evaluate.pressed.connect(func():
+		queue_free()
+		refactorings.evaluate_in_place()
+	)
+	%Print.pressed.connect(func():
+		queue_free()
+		refactorings.evaluate_and_print()
+	)
 
 func appear(a_code_edit: CodeEdit):
 	visible = true

--- a/godot/addons/refactorings/refactor_tooltip.tscn
+++ b/godot/addons/refactorings/refactor_tooltip.tscn
@@ -33,13 +33,11 @@ text = "@tool_button"
 
 [node name="ExtractVariable" type="Button" parent="PanelContainer/HBoxContainer"]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2
 text = "Extract Variable"
 
 [node name="InlineVariable" type="Button" parent="PanelContainer/HBoxContainer"]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2
 text = "Inline Variable"
 

--- a/godot/addons/refactorings/refactor_tooltip.tscn
+++ b/godot/addons/refactorings/refactor_tooltip.tscn
@@ -33,13 +33,25 @@ text = "@tool_button"
 
 [node name="ExtractVariable" type="Button" parent="PanelContainer/HBoxContainer"]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 text = "Extract Variable"
 
 [node name="InlineVariable" type="Button" parent="PanelContainer/HBoxContainer"]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 text = "Inline Variable"
+
+[node name="Evaluate" type="Button" parent="PanelContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Evaluate"
+
+[node name="Print" type="Button" parent="PanelContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Print"
 
 [node name="Texto" type="Label" parent="PanelContainer/HBoxContainer"]
 unique_name_in_owner = true

--- a/godot/addons/refactorings/refactorings.gd
+++ b/godot/addons/refactorings/refactorings.gd
@@ -118,6 +118,41 @@ func extract_variable():
 	code_edit.text = new_text
 	select_ranges(selection)
 
+func _evaluation_result_as_text(node, code_to_evaluate: String):
+	var expression := Expression.new()
+	var error = expression.parse(code_to_evaluate)
+	if error != OK:
+		print(expression.get_error_text())
+		return
+	var result = expression.execute([], node)
+	if expression.has_execute_failed():
+		print(expression.get_error_text())
+		return
+	var new_text: String
+	if result is String:
+		new_text = "\"%s\"" % result
+	else:
+		new_text = str(result)
+	return new_text
+
+func evaluate_in_place():
+	var code_edit = _code_edit()
+	var text = code_edit.get_selected_text()
+	var current_node = EditorInterface.get_selection().get_selected_nodes().front()
+	var result = _evaluation_result_as_text(current_node, text)
+	if result:
+		code_edit.insert_text_at_caret(result)
+
+func evaluate_and_print():
+	var code_edit = _code_edit()
+	var end_line = code_edit.get_selection_to_line()
+	var end_column = code_edit.get_line(end_line).length()
+	var text = code_edit.get_selected_text()
+	var current_node = EditorInterface.get_selection().get_selected_nodes().front()
+	var result = _evaluation_result_as_text(current_node, text)
+	if result:
+		code_edit.insert_text(" # " + str(result), end_line, end_column)
+
 func inline_variable():
 	var code_edit = _code_edit()
 	var previous_column = code_edit.get_caret_column()

--- a/godot/addons/refactorings/refactorings.gd
+++ b/godot/addons/refactorings/refactorings.gd
@@ -118,16 +118,26 @@ func extract_variable():
 	code_edit.text = new_text
 	select_ranges(selection)
 
-func _evaluation_result_as_text(node, code_to_evaluate: String):
+func _evaluation_result_as_text(code_to_evaluate: String):
 	var expression := Expression.new()
+
 	var error = expression.parse(code_to_evaluate)
 	if error != OK:
 		print(expression.get_error_text())
 		return
-	var result = expression.execute([], node)
+
+	var selected_nodes = EditorInterface.get_selection().get_selected_nodes()
+	var current_script = EditorInterface.get_script_editor().get_current_script()
+	var context = null
+	if not selected_nodes.is_empty() and selected_nodes.front().get_script() == current_script:
+			context = selected_nodes.front()
+
+	var result = expression.execute([], context)
+
 	if expression.has_execute_failed():
 		print(expression.get_error_text())
 		return
+
 	var new_text: String
 	if result is String:
 		new_text = "\"%s\"" % result
@@ -138,20 +148,33 @@ func _evaluation_result_as_text(node, code_to_evaluate: String):
 func evaluate_in_place():
 	var code_edit = _code_edit()
 	var text = code_edit.get_selected_text()
-	var current_node = EditorInterface.get_selection().get_selected_nodes().front()
-	var result = _evaluation_result_as_text(current_node, text)
+	var result = _evaluation_result_as_text(text)
 	if result:
 		code_edit.insert_text_at_caret(result)
 
 func evaluate_and_print():
 	var code_edit = _code_edit()
-	var end_line = code_edit.get_selection_to_line()
-	var end_column = code_edit.get_line(end_line).length()
 	var text = code_edit.get_selected_text()
-	var current_node = EditorInterface.get_selection().get_selected_nodes().front()
-	var result = _evaluation_result_as_text(current_node, text)
-	if result:
-		code_edit.insert_text(" # " + str(result), end_line, end_column)
+	var result = _evaluation_result_as_text(text)
+	if not result:
+		return
+
+	var evaluation_prefix: String = " #=> "
+	var line = code_edit.get_selection_to_line()
+	var line_previous_text: String = code_edit.get_line(line)
+	var line_column_end = line_previous_text.length()
+	var column: int
+	if evaluation_prefix in line_previous_text:
+		column = line_previous_text.find(evaluation_prefix)
+		code_edit.remove_text(
+			line, column,
+			line, line_column_end
+		)
+	else:
+		column = line_column_end
+	var new_evaluation: String = "%s %s" % [evaluation_prefix, result]
+	code_edit.insert_text(new_evaluation, line, column)
+	code_edit.grab_focus()
 
 func inline_variable():
 	var code_edit = _code_edit()

--- a/godot/addons/refactorings/refactorings.gd
+++ b/godot/addons/refactorings/refactorings.gd
@@ -129,7 +129,9 @@ func _evaluation_result_as_text(code_to_evaluate: String):
 	var selected_nodes = EditorInterface.get_selection().get_selected_nodes()
 	var current_script = EditorInterface.get_script_editor().get_current_script()
 	var context = null
-	if not selected_nodes.is_empty() and selected_nodes.front().get_script() == current_script:
+	if current_script.is_tool() \
+		and not selected_nodes.is_empty() \
+		and selected_nodes.front().get_script() == current_script:
 			context = selected_nodes.front()
 
 	var result = expression.execute([], context)


### PR DESCRIPTION
Dos opciones más en el tooltip de refactorings. Uno evalua el código y lo reemplaza en el lugar, el otro evalua el código y lo agrega en un comentario al final de la línea.

Si la línea ya tenia un comentario de la forma ` # => `, entonces se reemplaza porque se interpreta que fue una evaluación anterior.

Si el nodo seleccionado en el árbol de escenas tiene asignado el script que se está editando y además el script es una `@tool`, entonces se usará el nodo seleccionado como contexto en el cual evaluar la expresión. **ESTO** extiende un poco la funcionalidad nativa de godot de poder evaluar código en el editor.

https://github.com/user-attachments/assets/ee1a5493-aac7-4350-93d5-0e921818ed74

