### PR TITLE
Refactor inline variable

### DIFF
--- a/rust/src/refactorings.rs
+++ b/rust/src/refactorings.rs
@@ -145,8 +145,7 @@ impl<'a> Program {
             for (idx, statement) in statements.clone().iter().enumerate() {
                 if idx == statement_idx {
                 } else {
-            
-                    match statement.clone().kind {
+                    Some(match statement.clone().kind {
                         StatementKind::Pass
                         | StatementKind::Unknown(_)
                         | StatementKind::Return(None) => new_statements.push(statement.clone()),
@@ -161,7 +160,7 @@ impl<'a> Program {
                                         StatementKind::VarDeclaration(var_name, new_expr),
                                     ))
                                 }
-                                None => new_statements.push(statement.clone()),
+                                None => break,
                             }
                         }
                         StatementKind::Expression(expression) => match expression.replace_variable_usage(
@@ -170,7 +169,7 @@ impl<'a> Program {
                         ) {
                             Some((new_expr, _lines_to_select)) => new_statements
                                 .push(Statement::new(None, StatementKind::Expression(new_expr))),
-                            None => new_statements.push(statement.clone()),
+                            None => break,
                         },
                         StatementKind::Return(Some(expression)) => match expression.replace_variable_usage(
                             variable_name.to_string(),
@@ -178,9 +177,9 @@ impl<'a> Program {
                         ) {
                             Some((new_expr, _lines_to_select)) => new_statements
                                 .push(Statement::new(None, StatementKind::Return(Some(new_expr)))),
-                            None => new_statements.push(statement.clone()),
+                            None => break,
                         },
-                    }
+                    }).or_else(|| Some(new_statements.push(statement.clone())));
                 }
             }
             Declaration::new(

--- a/rust/src/refactorings.rs
+++ b/rust/src/refactorings.rs
@@ -104,6 +104,77 @@ impl<'a> Program {
         vec![]
     }
 
+    fn replace_variable_usage(
+        old_expression: Expression,
+        variable_name: String,
+        expression_to_inline: Expression,
+    ) -> Option<(Expression, Vec<Range<LineCol>>)> {
+        match old_expression.clone().kind {
+            ExpressionKind::Unknown(var_name) if var_name == variable_name => {
+                Some((expression_to_inline, vec![old_expression.line_col_range()]))
+            }
+            ExpressionKind::LiteralInt(_)
+            | ExpressionKind::Unknown(_)
+            | ExpressionKind::LiteralSelf => None,
+            ExpressionKind::BinaryOperation(expression1, op, expression2) => {
+                let maybe_replacement1 = Self::replace_variable_usage(
+                    *expression1.clone(),
+                    variable_name.clone(),
+                    expression_to_inline.clone(),
+                );
+                let maybe_replacement2 = Self::replace_variable_usage(
+                    *expression2.clone(),
+                    variable_name,
+                    expression_to_inline,
+                );
+                let mut lines_to_select = vec![];
+                let mut new_expression1: Expression = *expression1;
+                let mut new_expression2: Expression = *expression2;
+                if let Some((new_expr1, mut lines_to_select1)) = maybe_replacement1
+                {
+                    lines_to_select.append(&mut lines_to_select1);
+                    new_expression1 = new_expr1;
+                }
+                if let Some((new_expr2, mut lines_to_select2)) = maybe_replacement2
+                {
+                    lines_to_select.append(&mut lines_to_select2);
+                    new_expression2 = new_expr2;
+                }
+                let kind = ExpressionKind::BinaryOperation(
+                    Box::new(new_expression1),
+                    op,
+                    Box::new(new_expression2),
+                );
+                Some((Expression::new(None, kind), lines_to_select))
+            }
+            ExpressionKind::MessageSend(expression, message_name, vec) => {
+                let maybe_replacement = Self::replace_variable_usage(
+                    *expression.clone(),
+                    variable_name.clone(),
+                    expression_to_inline.clone(),
+                );
+                match maybe_replacement {
+                    Some((new_expr, lines_to_select)) => {
+                        let kind = ExpressionKind::MessageSend(
+                            Box::new(new_expr),
+                            message_name,
+                            vec,
+                        );
+                        Some((Expression::new(None, kind), lines_to_select))
+                    }
+
+                    None => None,
+                }
+            }
+            ExpressionKind::VariableUsage(var_name)
+                if var_name == variable_name =>
+            {
+                Some((expression_to_inline, vec![]))
+            }
+            ExpressionKind::VariableUsage(_) => None,
+        }
+    }
+
     pub fn inline_variable(
         &self,
         start_line_column: LineCol,
@@ -145,83 +216,13 @@ impl<'a> Program {
             for (idx, statement) in statements.clone().iter().enumerate() {
                 if idx == statement_idx {
                 } else {
-                    fn replace_variable_usage<'a>(
-                        old_expression: Expression,
-                        variable_name: String,
-                        expression_to_inline: Expression,
-                    ) -> Option<(Expression, Vec<Range<LineCol>>)> {
-                        match old_expression.clone().kind {
-                            ExpressionKind::Unknown(var_name) if var_name == variable_name => {
-                                Some((expression_to_inline, vec![old_expression.line_col_range()]))
-                            }
-                            ExpressionKind::LiteralInt(_)
-                            | ExpressionKind::Unknown(_)
-                            | ExpressionKind::LiteralSelf => None,
-                            ExpressionKind::BinaryOperation(expression1, op, expression2) => {
-                                let maybe_replacement1 = replace_variable_usage(
-                                    *expression1.clone(),
-                                    variable_name.clone(),
-                                    expression_to_inline.clone(),
-                                );
-                                let maybe_replacement2 = replace_variable_usage(
-                                    *expression2.clone(),
-                                    variable_name,
-                                    expression_to_inline,
-                                );
-                                let mut lines_to_select = vec![];
-                                let mut new_expression1: Expression = *expression1;
-                                let mut new_expression2: Expression = *expression2;
-                                if let Some((new_expr1, mut lines_to_select1)) = maybe_replacement1
-                                {
-                                    lines_to_select.append(&mut lines_to_select1);
-                                    new_expression1 = new_expr1;
-                                }
-                                if let Some((new_expr2, mut lines_to_select2)) = maybe_replacement2
-                                {
-                                    lines_to_select.append(&mut lines_to_select2);
-                                    new_expression2 = new_expr2;
-                                }
-                                let kind = ExpressionKind::BinaryOperation(
-                                    Box::new(new_expression1),
-                                    op,
-                                    Box::new(new_expression2),
-                                );
-                                Some((Expression::new(None, kind), lines_to_select))
-                            }
-                            ExpressionKind::MessageSend(expression, message_name, vec) => {
-                                let maybe_replacement = replace_variable_usage(
-                                    *expression.clone(),
-                                    variable_name.clone(),
-                                    expression_to_inline.clone(),
-                                );
-                                match maybe_replacement {
-                                    Some((new_expr, lines_to_select)) => {
-                                        let kind = ExpressionKind::MessageSend(
-                                            Box::new(new_expr),
-                                            message_name,
-                                            vec,
-                                        );
-                                        Some((Expression::new(None, kind), lines_to_select))
-                                    }
-
-                                    None => None,
-                                }
-                            }
-                            ExpressionKind::VariableUsage(var_name)
-                                if var_name == variable_name =>
-                            {
-                                Some((expression_to_inline, vec![]))
-                            }
-                            ExpressionKind::VariableUsage(_) => None,
-                        }
-                    }
-
+            
                     match statement.clone().kind {
                         StatementKind::Pass
                         | StatementKind::Unknown(_)
                         | StatementKind::Return(None) => new_statements.push(statement.clone()),
                         StatementKind::VarDeclaration(var_name, expression) => {
-                            match replace_variable_usage(
+                            match Self::replace_variable_usage(
                                 expression,
                                 variable_name.to_string(),
                                 expr_to_inline.clone(),
@@ -235,7 +236,7 @@ impl<'a> Program {
                                 None => new_statements.push(statement.clone()),
                             }
                         }
-                        StatementKind::Expression(expression) => match replace_variable_usage(
+                        StatementKind::Expression(expression) => match Self::replace_variable_usage(
                             expression,
                             variable_name.to_string(),
                             expr_to_inline.clone(),
@@ -244,7 +245,7 @@ impl<'a> Program {
                                 .push(Statement::new(None, StatementKind::Expression(new_expr))),
                             None => new_statements.push(statement.clone()),
                         },
-                        StatementKind::Return(Some(expression)) => match replace_variable_usage(
+                        StatementKind::Return(Some(expression)) => match Self::replace_variable_usage(
                             expression,
                             variable_name.to_string(),
                             expr_to_inline.clone(),

--- a/rust/src/tests.rs
+++ b/rust/src/tests.rs
@@ -333,13 +333,14 @@ mod tests {
 
         let program = GDScriptParser::parse_to_program(input);
 
-        let new_program = program.inline_variable((1, 5), (1, 5)).0;
+        let (new_program, lines_to_select) = program.inline_variable((1, 5), (1, 5));
 
         let expected = text_block_fnl! {
           "func foo():"
           "\t4 + 2"
         };
         assert_program_prints_to(new_program, expected);
+        assert_eq!(lines_to_select, vec![]);
     }
 
     #[test]
@@ -522,9 +523,10 @@ func foo():
             )]),
         );
 
-        let new_program = program.inline_variable((1, 5), (1, 8)).0;
+        let (new_program, lines_to_select) = program.inline_variable((1, 5), (1, 8));
 
         assert_program_prints_to(new_program, "func foo():\n\t2 + 3\n");
+        assert_eq!(lines_to_select, vec![]);
     }
 
     #[test]
@@ -532,9 +534,10 @@ func foo():
         let input = "func bar():\n\tpass\nfunc foo():\n\tvar suma = 2 + 3\n\tsuma\n";
         let program = GDScriptParser::parse_to_program(input);
 
-        let new_program = program.inline_variable((3, 5), (3, 8)).0;
+        let (new_program, lines_to_select) = program.inline_variable((3, 5), (3, 8));
 
         assert_program_prints_to(new_program, "func bar():\n\tpass\nfunc foo():\n\t2 + 3\n");
+        assert_eq!(lines_to_select, vec![]);
     }
     #[test]
     fn test_program_inline_variable_inside_return() {
@@ -557,9 +560,10 @@ func foo():
             )]),
         );
 
-        let new_program = program.inline_variable((1, 5), (1, 8)).0;
+        let (new_program, lines_to_select) = program.inline_variable((1, 5), (1, 8));
 
         assert_program_prints_to(new_program, "func foo():\n\treturn 2 + 3\n");
+        assert_eq!(lines_to_select, vec![]);
     }
 
     #[test]


### PR DESCRIPTION
- Movido `replace_variable_usage` a `Statement`
- No estoy super seguro de esta decisión, pero cree una función auxiliar y privada que hace básicamente todo el inline pero devuelve un Option, y la función pública inline está definida como: intentar usar la otra, y si es None, devolver el programa como venía sin líneas a seleccionar. ¿Qué opinan?
- Eliminada un poco de repetición de lógica también.

⚠️ En el inline variable no se estaban testeando las líneas devueltas, y además, parece que estaba devolviendose siempre vacío, o al menos eso encontré cuando escribí los asserts en los tests ⚠️ 
Tras este refactor, ese comportamiento quedó igual, falta arreglar el refactor para que devuelva donde seleccionar en el texto (si es que debería, que no estoy seguro la verdad 🤔 ).